### PR TITLE
fix

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,9 +1,7 @@
 <configuration scan="true" scanPeriod="5 seconds" debug="false" packagingDate="true">
 
-    <conversionRule conversionWord="traceToken" converterClass="io.kamon.sample.CustomLogbackTraceTokenConverter" />
-
     <property name="LOG_ENCODER_PATTERN"
-              value="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %logger{36} %X{akkaTimestamp} [%traceToken] - %msg%n"
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %logger{36} %X{akkaTimestamp} [%X{traceToken}] - %msg%n"
     />
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">

--- a/src/main/scala/io/kamon/sample/Main.scala
+++ b/src/main/scala/io/kamon/sample/Main.scala
@@ -38,21 +38,6 @@ class HttpRequestHandler(routes: Route) extends HttpServiceActor with ActorLoggi
   override def receive: Receive = runRoute(routes)
 }
 
-/**
-  * This is a copy
-  *
-  * @see kamon.trace.logging.LogbackTraceTokenConverter
-  */
-class CustomLogbackTraceTokenConverter extends LogbackTraceTokenConverter {
-
-  override def convert(event: ILoggingEvent): String = {
-
-    println(event.getMDCPropertyMap)
-    super.convert(event)
-  }
-}
-
-
 object Main extends App {
 
   implicit val system = ActorSystem("kamon")


### PR DESCRIPTION
@neowulf33 this is the way, kamon automatically propagate the values of ```TraceContext``` to the ```MDC``` throught https://github.com/kamon-io/Kamon/blob/master/kamon-akka/src/main/scala/kamon/akka/instrumentation/ActorLoggingInstrumentation.scala#L42-L48

in order to test: ```curl localhost:8080/build -v -i -H 'X-Request-Id:kamon-test'```
